### PR TITLE
Add customisable keyserver, fixes #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The package I got contained a Python file that generated the JSON file.
 
 ### Soft dependencies
 
-- On Debian and derivatives, you need the *puppetlabs/apt* module.
+- On Debian and derivatives, you need the *puppetlabs/apt* module at minimum version 6.2.0
 - On RedHat and derivatives, you need the *puppetlabs/yumrepo_core* module.
 
 ## Usage

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,6 +2,7 @@
 
 microsoft_defender_atp_agent::default_channel: prod
 microsoft_defender_atp_agent::default_manage_sources: true
+microsoft_defender_atp_agent::default_keyserver: 'hkps://keyserver.ubuntu.com:443'
 # Shouldn't need to change the below unless MS change something
 microsoft_defender_atp_agent::package_name: mdatp
 microsoft_defender_atp_agent::target_json_path: /etc/opt/microsoft/mdatp/mdatp_onboard.json

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,6 +1,6 @@
 # @summary Puppet module to install Microsoft Defender for Endpoint on Linux.
 #
-# @param onboarding_json_file Source (as in *file* resource attribute called *source*) of the JSON file you extracted from the onboarding package that your Defender manager gave you.
+# @param onboarding_json_file Source (as in *file* resource attribute called *source*) of the JSON file extracted from your site's Defender onboarding package.
 # @param channel The release channel you want to use.
 # @param manage_sources Allows you to manage the repository sources yourself (false) or allow this module to manage them for you (true).
 # @param distro Allows you to override the distro MS say you should state to get the right package. I calculate this for you in Hiera.
@@ -20,7 +20,8 @@ class microsoft_defender_atp_agent (
   Optional[String] $distro                                        = lookup('microsoft_defender_atp_agent::default_distro'),
   Optional[String] $version                                       = $::facts['os']['release']['major'],
   Optional[Enum['prod','insiders-fast','insiders-slow']] $channel = lookup('microsoft_defender_atp_agent::default_channel'), # prod
-  Optional[Boolean] $manage_sources                               = lookup('microsoft_defender_atp_agent::default_manage_sources') # true
+  Optional[Boolean] $manage_sources                               = lookup('microsoft_defender_atp_agent::default_manage_sources'), # true
+  Optional[String] $keyserver                                     = lookup('microsoft_defender_atp_agent::default_keyserver') # hkps://keyserver.ubuntu.com:443
 ) {
 
   # I run a lot of armhf Pis and this endpoint agent won't work on them because the

--- a/manifests/sources.pp
+++ b/manifests/sources.pp
@@ -19,7 +19,7 @@ class microsoft_defender_atp_agent::sources {
         repos    => 'main',
         key      => {
           'id'     => 'BC528686B50D79E339D3721CEB3E94ADBE1229CF',
-          'server' => 'keyserver.ubuntu.com',
+          'server' => $microsoft_defender_atp_agent::keyserver,
         },
       }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "ncsteam-microsoft_defender_atp_agent",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "author": "Helen Griffiths",
   "summary": "",
   "license": "CC-BY-4.0",

--- a/spec/classes/sources_spec.rb
+++ b/spec/classes/sources_spec.rb
@@ -37,7 +37,16 @@ describe 'microsoft_defender_atp_agent::sources' do
     on_supported_os(ubuntu).each do |_os, os_facts|
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_apt__source('microsoftpackages').with('location' => %r{ubuntu}, 'release' => 'prod') }
+      it {
+        is_expected.to contain_apt__source('microsoftpackages').with(
+          'location' => %r{ubuntu},
+          'release'  => 'prod',
+          'key'      => {
+            'server' => 'hkps://keyserver.ubuntu.com:443',
+            'id'     => 'BC528686B50D79E339D3721CEB3E94ADBE1229CF',
+          },
+        )
+      }
     end
   end
 
@@ -54,7 +63,16 @@ describe 'microsoft_defender_atp_agent::sources' do
     on_supported_os(debian).each do |_os, os_facts|
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_apt__source('microsoftpackages').with('location' => %r{debian}, 'release' => 'prod') }
+      it {
+        is_expected.to contain_apt__source('microsoftpackages').with(
+          'location' => %r{debian},
+          'release'  => 'prod',
+          'key'      => {
+            'server' => 'hkps://keyserver.ubuntu.com:443',
+            'id'     => 'BC528686B50D79E339D3721CEB3E94ADBE1229CF',
+          },
+        )
+      }
     end
   end
 


### PR DESCRIPTION
New features:
- parameterise the keyserver used by `apt::key`;
- set the default  keyserver to _hkps://keyserver.ubuntu.com:443_ to work by default in heavily-firewalled environments;
- use a later minimum version, 6.2.0, of the puppetlabs/apt module to support the hkps protocol and and the use of port 443.