### PR TITLE
Add Oracle Linux Support

### DIFF
--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -1,3 +1,3 @@
 ---
 
-microsoft_defender_atp_agent::distro: oraclelinux
+microsoft_defender_atp_agent::distro: rhel

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -1,0 +1,3 @@
+---
+
+microsoft_defender_atp_agent::distro: OracleLinux

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -1,3 +1,3 @@
 ---
 
-microsoft_defender_atp_agent::distro: OracleLinux
+microsoft_defender_atp_agent::distro: oraclelinux

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -1,3 +1,3 @@
 ---
 
-microsoft_defender_atp_agent::distro: ol
+microsoft_defender_atp_agent::distro: oraclelinux

--- a/data/os/OracleLinux.yaml
+++ b/data/os/OracleLinux.yaml
@@ -1,3 +1,3 @@
 ---
 
-microsoft_defender_atp_agent::distro: oraclelinux
+microsoft_defender_atp_agent::distro: ol

--- a/manifests/sources.pp
+++ b/manifests/sources.pp
@@ -30,7 +30,7 @@ class microsoft_defender_atp_agent::sources {
       }
     }
 
-    /(centos|rhel|oraclelinux)/: {
+    /(centos|rhel)/: {
       yumrepo { $microsoft_defender_atp_agent::sourcename :
         baseurl  => "https://packages.microsoft.com/${microsoft_defender_atp_agent::distro}/${microsoft_defender_atp_agent::version}/${microsoft_defender_atp_agent::channel}",
         descr    => "packages-microsoft-com-prod-${microsoft_defender_atp_agent::channel}",

--- a/manifests/sources.pp
+++ b/manifests/sources.pp
@@ -30,7 +30,7 @@ class microsoft_defender_atp_agent::sources {
       }
     }
 
-    /(centos|rhel|ol)/: {
+    /(centos|rhel|oraclelinux)/: {
       yumrepo { $microsoft_defender_atp_agent::sourcename :
         baseurl  => "https://packages.microsoft.com/${microsoft_defender_atp_agent::distro}/${microsoft_defender_atp_agent::version}/${microsoft_defender_atp_agent::channel}",
         descr    => "packages-microsoft-com-prod-${microsoft_defender_atp_agent::channel}",

--- a/manifests/sources.pp
+++ b/manifests/sources.pp
@@ -30,7 +30,7 @@ class microsoft_defender_atp_agent::sources {
       }
     }
 
-    /(centos|rhel|oracle)/: {
+    /(centos|rhel|oraclelinux)/: {
       yumrepo { $microsoft_defender_atp_agent::sourcename :
         baseurl  => "https://packages.microsoft.com/${microsoft_defender_atp_agent::distro}/${microsoft_defender_atp_agent::version}/${microsoft_defender_atp_agent::channel}",
         descr    => "packages-microsoft-com-prod-${microsoft_defender_atp_agent::channel}",

--- a/manifests/sources.pp
+++ b/manifests/sources.pp
@@ -30,7 +30,7 @@ class microsoft_defender_atp_agent::sources {
       }
     }
 
-    /(centos|rhel)/: {
+    /(centos|rhel|oracle)/: {
       yumrepo { $microsoft_defender_atp_agent::sourcename :
         baseurl  => "https://packages.microsoft.com/${microsoft_defender_atp_agent::distro}/${microsoft_defender_atp_agent::version}/${microsoft_defender_atp_agent::channel}",
         descr    => "packages-microsoft-com-prod-${microsoft_defender_atp_agent::channel}",

--- a/manifests/sources.pp
+++ b/manifests/sources.pp
@@ -30,7 +30,7 @@ class microsoft_defender_atp_agent::sources {
       }
     }
 
-    /(centos|rhel|oraclelinux)/: {
+    /(centos|rhel|ol)/: {
       yumrepo { $microsoft_defender_atp_agent::sourcename :
         baseurl  => "https://packages.microsoft.com/${microsoft_defender_atp_agent::distro}/${microsoft_defender_atp_agent::version}/${microsoft_defender_atp_agent::channel}",
         descr    => "packages-microsoft-com-prod-${microsoft_defender_atp_agent::channel}",

--- a/metadata.json
+++ b/metadata.json
@@ -27,7 +27,8 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "8"
+        "8",
+        "9"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 8.0.0"
+      "version_requirement": ">= 4.25.1 < 9.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -25,6 +25,12 @@
       ]
     },
     {
+      "operatingsystem": "OracleLinux",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "10"

--- a/spec/classes/sources_spec.rb
+++ b/spec/classes/sources_spec.rb
@@ -115,10 +115,6 @@ describe 'microsoft_defender_atp_agent::sources' do
             'operatingsystemrelease' => ['7', '8'],
           },
           {
-            'operatingsystem'        => 'OracleLinux',
-            'operatingsystemrelease' => ['7', '8', '9'],
-          },
-          {
             'operatingsystem'        => 'CentOS',
             'operatingsystemrelease' => ['8'],
           },
@@ -132,6 +128,24 @@ describe 'microsoft_defender_atp_agent::sources' do
       end # on_supported_os
     end # RHEL tests
   end # Bare essential parameters
+
+  context 'OracleLinux tests' do
+    rhel = {
+      supported_os: [
+        {
+          'operatingsystem'        => 'OracleLinux',
+          'operatingsystemrelease' => ['7', '8', '9'],
+        },
+      ],
+    }
+
+    on_supported_os(oraclelinux).each do |_os, os_facts|
+      let(:facts) { os_facts }
+
+      it { is_expected.to contain_yumrepo('microsoftpackages').with('baseurl' => %r{oraclelinux}) }
+    end # on_supported_os
+  end # OracleLinux tests
+end # Bare essential parameters
 
   context 'Ubuntu tests with custom source filename' do
     let(:pre_condition) do

--- a/spec/classes/sources_spec.rb
+++ b/spec/classes/sources_spec.rb
@@ -142,7 +142,7 @@ describe 'microsoft_defender_atp_agent::sources' do
     on_supported_os(oraclelinux).each do |_os, os_facts|
       let(:facts) { os_facts }
 
-      it { is_expected.to contain_yumrepo('microsoftpackages').with('baseurl' => %r{oraclelinux}) }
+      it { is_expected.to contain_yumrepo('microsoftpackages').with('baseurl' => %r{rhel}) }
     end # on_supported_os
   end # OracleLinux tests
 end # Bare essential parameters

--- a/spec/classes/sources_spec.rb
+++ b/spec/classes/sources_spec.rb
@@ -139,7 +139,7 @@ describe 'microsoft_defender_atp_agent::sources' do
       ],
     }
 
-    on_supported_os(oraclelinux).each do |_os, os_facts|
+    on_supported_os(ol).each do |_os, os_facts|
       let(:facts) { os_facts }
 
       it { is_expected.to contain_yumrepo('microsoftpackages').with('baseurl' => %r{oraclelinux}) }

--- a/spec/classes/sources_spec.rb
+++ b/spec/classes/sources_spec.rb
@@ -139,7 +139,7 @@ describe 'microsoft_defender_atp_agent::sources' do
       ],
     }
 
-    on_supported_os(ol).each do |_os, os_facts|
+    on_supported_os(oraclelinux).each do |_os, os_facts|
       let(:facts) { os_facts }
 
       it { is_expected.to contain_yumrepo('microsoftpackages').with('baseurl' => %r{oraclelinux}) }

--- a/spec/classes/sources_spec.rb
+++ b/spec/classes/sources_spec.rb
@@ -115,6 +115,10 @@ describe 'microsoft_defender_atp_agent::sources' do
             'operatingsystemrelease' => ['7', '8'],
           },
           {
+            'operatingsystem'        => 'OracleLinux',
+            'operatingsystemrelease' => ['7', '8', '9'],
+          },
+          {
             'operatingsystem'        => 'CentOS',
             'operatingsystemrelease' => ['8'],
           },


### PR DESCRIPTION
This Pull Request adds support for the Oracle Linux Operating System Family.

I have personally tested this on Oracle Linux 8, but the logic should work for the 7 and 9 variants.